### PR TITLE
Task/type update validation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.2 - 2023-10-04
+
+### Added
+
+- Added new type called VCClaimsWithVCDataModel that can be used to create VCSDJWT
+
+### Removed
+
+- The CredentialStatus type as it was not properly defined based on the specfications [JWT and CWT Status List](https://datatracker.ietf.org/doc/html/draft-looker-oauth-jwt-cwt-status-list-01)
+
+### Changed
+
+- Updated issuer demo script to use the new type VCClaimsWithVCDataModel
+
 ## 0.0.1 - 2023-10-03
 
 Initial version

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Here's an example:
 import { DisclosureFrame, Hasher, SDJWTPayload, Signer, base64encode } from '@meeco/sd-jwt';
 import { createHash } from 'crypto';
 import { JWTHeaderParameters, JWTPayload, KeyLike, SignJWT, exportJWK, generateKeyPair } from 'jose';
-import { HasherConfig, Issuer, SignerConfig, VCClaims, defaultHashAlgorithm, supportedAlgorithm } from '../src/index';
+import {
+  CreateSDJWTPayload,
+  HasherConfig,
+  Issuer,
+  SignerConfig,
+  VCClaims,
+  defaultHashAlgorithm,
+  supportedAlgorithm,
+} from '@meeco/sd-jwt-vc';
 
 const hasherCallbackFn = function (alg: string = defaultHashAlgorithm): Hasher {
   return (data: string): string => {
@@ -76,7 +84,7 @@ async function main() {
 
   const holderPublicKey = await exportJWK(keyPair.publicKey);
 
-  const payload: SDJWTPayload = {
+  const payload: CreateSDJWTPayload = {
     iat: Date.now(),
     cnf: {
       jwk: holderPublicKey,
@@ -118,7 +126,7 @@ To use the Holder class, you need to create an instance of it by passing in a Ho
 ```typescript
 import { KeyBindingVerifier, Signer, decodeJWT } from '@meeco/sd-jwt';
 import { JWK, JWTHeaderParameters, JWTPayload, KeyLike, SignJWT, importJWK, jwtVerify } from 'jose';
-import { Holder, SignerConfig, supportedAlgorithm } from 'src';
+import { Holder, SignerConfig, supportedAlgorithm } from '@meeco/sd-jwt-vc';
 
 const signerCallbackFn = function (privateKey: Uint8Array | KeyLike): Signer {
   return (protectedHeader: JWTHeaderParameters, payload: JWTPayload): Promise<string> => {
@@ -223,7 +231,7 @@ Here's an example:
 import { Hasher, KeyBindingVerifier, base64encode, decodeJWT } from '@meeco/sd-jwt';
 import { createHash } from 'crypto';
 import { JWK, KeyLike, importJWK, jwtVerify } from 'jose';
-import { Verifier, defaultHashAlgorithm, supportedAlgorithm } from 'src';
+import { Verifier, defaultHashAlgorithm, supportedAlgorithm } from '@meeco/sd-jwt-vc';
 
 function verifierCallbackFn(publicKey: Uint8Array | KeyLike) {
   return async (jwt: string): Promise<boolean> => {

--- a/demo/issuer.ts
+++ b/demo/issuer.ts
@@ -6,7 +6,7 @@ import {
   HasherConfig,
   Issuer,
   SignerConfig,
-  VCClaims,
+  VCClaimsWithVCDataModel,
   defaultHashAlgorithm,
   supportedAlgorithm,
 } from '../dev/src';
@@ -29,7 +29,7 @@ async function main() {
 
   const hasher: HasherConfig = {
     alg: 'sha256',
-    callback: hasherCallbackFn('sha256'),
+    callback: hasherCallbackFn('sha-256'),
   };
   const signer: SignerConfig = {
     alg: supportedAlgorithm.EdDSA,
@@ -45,22 +45,34 @@ async function main() {
     cnf: {
       jwk: holderPublicKey,
     },
-    iss: 'https://valid.issuer.url',
+    iss: 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK',
   };
 
-  const vcClaims: VCClaims = {
-    type: 'VerifiableCredential',
-    status: {
-      idx: 'statusIndex',
-      uri: 'https://valid.status.url',
-    },
-    person: {
-      name: 'test person',
-      age: 25,
+  const vcClaims: VCClaimsWithVCDataModel = {
+    vc: {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      id: '9bcc9aaa-3bdc-4414-9450-739c295c752c',
+      type: 'StudentID',
+      issuer: 'did:ebsi:zvHWX359A3CvfJnCYaAiAde',
+      validFrom: '2023-01-01T00:00:00Z',
+      validUntil: '2033-01-01T00:00:00Z',
+      credentialSubject: {
+        id: 'did:key:z2dmzD81cgPx8Vki7JbuuMmFYrWPgYoytykUZ3eyqht1j9KbsDbVZXdb3jzCagESyY4EE2x7Yjx3gNwctoEuRCKKDrdNP3HPFtG8RTvBiYStT5ghBHhHizH2Dy6xQtW3Pd2SecizL9b2jzDCMr7Ka5cRAWZFwvqwAtwTT7xet769y9ERh6',
+        familyName: 'Carroll',
+        givenName: 'Lewis',
+        birthDate: '1832-01-27',
+        student: true,
+      },
+      credentialSchema: {
+        id: 'https://api-pilot.ebsi.eu/trusted-schemas-registry/v2/schemas/0x23039e6356ea6b703ce672e7cfac0b42765b150f63df78e2bd18ae785787f6a2',
+        type: 'FullJsonSchemaValidator2021',
+      },
     },
   };
 
-  const sdVCClaimsDisclosureFrame: DisclosureFrame = { person: { _sd: ['name', 'age'] } };
+  const sdVCClaimsDisclosureFrame: DisclosureFrame = {
+    vc: { credentialSubject: { _sd: ['familyName', 'givenName', 'birthDate', 'student'] } },
+  };
 
   const result = await issuer.createVCSDJWT(vcClaims, payload, sdVCClaimsDisclosureFrame);
   console.log(result);

--- a/demo/issuer.ts
+++ b/demo/issuer.ts
@@ -1,7 +1,15 @@
-import { DisclosureFrame, Hasher, SDJWTPayload, Signer, base64encode } from '@meeco/sd-jwt';
+import { DisclosureFrame, Hasher, Signer, base64encode } from '@meeco/sd-jwt';
 import { createHash } from 'crypto';
 import { JWTHeaderParameters, JWTPayload, KeyLike, SignJWT, exportJWK, generateKeyPair } from 'jose';
-import { HasherConfig, Issuer, SignerConfig, VCClaims, defaultHashAlgorithm, supportedAlgorithm } from '../dev/src';
+import {
+  CreateSDJWTPayload,
+  HasherConfig,
+  Issuer,
+  SignerConfig,
+  VCClaims,
+  defaultHashAlgorithm,
+  supportedAlgorithm,
+} from '../dev/src';
 
 const hasherCallbackFn = function (alg: string = defaultHashAlgorithm): Hasher {
   return (data: string): string => {
@@ -32,7 +40,7 @@ async function main() {
 
   const holderPublicKey = await exportJWK(keyPair.publicKey);
 
-  const payload: SDJWTPayload = {
+  const payload: CreateSDJWTPayload = {
     iat: Date.now(),
     cnf: {
       jwk: holderPublicKey,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt-vc",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@meeco/sd-jwt": "^0.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "SD-JWT VC implementation in typescript",
   "scripts": {
     "build": "tsc",

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -1,9 +1,9 @@
 import { generateKeyPair } from 'jose';
 
-import { DisclosureFrame, SDJWTPayload, decodeDisclosure, decodeJWT } from '@meeco/sd-jwt';
+import { DisclosureFrame, decodeDisclosure, decodeJWT } from '@meeco/sd-jwt';
 import { Issuer } from './issuer';
 import { hasherCallbackFn, signerCallbackFn } from './test-utils/helpers';
-import { HasherConfig, SD_JWT_FORMAT_SEPARATOR, SignerConfig, VCClaims } from './types';
+import { CreateSDJWTPayload, HasherConfig, SD_JWT_FORMAT_SEPARATOR, SignerConfig, VCClaims } from './types';
 import { supportedAlgorithm } from './util';
 
 describe('Issuer', () => {
@@ -34,7 +34,7 @@ describe('Issuer', () => {
       crv: 'P-256',
     };
 
-    const payload: SDJWTPayload = {
+    const payload: CreateSDJWTPayload = {
       iat: Date.now(),
       cnf: {
         jwk: holderPublicKey,
@@ -295,35 +295,7 @@ describe('Issuer', () => {
         status: 'invalid-status',
       };
 
-      expect(() => issuer.validateVCClaims(claims as any)).toThrowError(
-        'Payload status must be an object with idx and uri properties',
-      );
-    });
-
-    it('should throw an error if status.idx is missing', () => {
-      const claims = {
-        type: 'VerifiableCredential',
-        status: {
-          uri: 'https://valid.status.url',
-        },
-      };
-
-      expect(() => issuer.validateVCClaims(claims as any)).toThrowError(
-        'Payload status must be an object with idx and uri properties',
-      );
-    });
-
-    it('should throw an error if status.uri is missing', () => {
-      const claims = {
-        type: 'VerifiableCredential',
-        status: {
-          idx: 'statusIndex',
-        },
-      };
-
-      expect(() => issuer.validateVCClaims(claims as any)).toThrowError(
-        'Payload status must be an object with idx and uri properties',
-      );
+      expect(() => issuer.validateVCClaims(claims as any)).toThrowError('Payload status must be an object');
     });
 
     it('should not throw an error if all properties are valid', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,6 @@ import { supportedAlgorithm } from './util.js';
 export const SD_JWT_FORMAT_SEPARATOR = '~';
 
 export type JWT = string;
-export interface CredentialStatus {
-  idx: string;
-  uri: string;
-}
 
 export interface Cnf {
   jwk: JWK;
@@ -35,9 +31,23 @@ export interface PresentSDJWTPayload extends JWTPayload {
 
 export interface VCClaims {
   type: string;
-  status?: CredentialStatus;
+  status?: Record<string, any>;
   sub?: string;
   [key: string]: unknown;
+}
+
+export interface VCClaimsWithVCDataModel {
+  vc: Extensible<{
+    '@context': string[] | string;
+    type: string[] | string;
+    credentialSubject: Record<string, any>;
+    credentialStatus?: {
+      id: string;
+      type: string;
+    };
+    evidence?: any;
+    termsOfUse?: any;
+  }>;
 }
 
 export interface IssuerMetadata {
@@ -61,3 +71,5 @@ export interface JSONWebKeySet {
 }
 
 export type NonceGenerator = (length?: number) => string;
+
+type Extensible<T> = T & { [x: string]: any };


### PR DESCRIPTION
### Added

- New type called `VCClaimsWithVCDataModel` that can be used to create VCSDJWT

### Removed

- The CredentialStatus type as it was not properly defined based on the specifications [JWT and CWT Status List](https://datatracker.ietf.org/doc/html/draft-looker-oauth-jwt-cwt-status-list-01)

### Changed

- Updated issuer demo script to use the new type VCClaimsWithVCDataModel