### PR TITLE
fix: signer returning a signed jwt instead of signature; bump up version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.3 - 2023-10-18
+
+### Changed
+
+- Upgrade `sd-jwt` dependency
+- Expect Signer function to return a signature string instead of a signed compactJWT
+
 ## 0.0.2 - 2023-10-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const hasherCallbackFn = function (alg: string = defaultHashAlgorithm): Hasher {
 
 const signerCallbackFn = function (privateKey: Uint8Array | KeyLike): Signer {
   return (protectedHeader: JWTHeaderParameters, payload: JWTPayload): Promise<string> => {
-    return new SignJWT(payload).setProtectedHeader(protectedHeader).sign(privateKey);
+    return (await new SignJWT(payload).setProtectedHeader(protectedHeader).sign(privateKey)).split('.').pop();
   };
 };
 
@@ -130,7 +130,7 @@ import { Holder, SignerConfig, supportedAlgorithm } from '@meeco/sd-jwt-vc';
 
 const signerCallbackFn = function (privateKey: Uint8Array | KeyLike): Signer {
   return (protectedHeader: JWTHeaderParameters, payload: JWTPayload): Promise<string> => {
-    return new SignJWT(payload).setProtectedHeader(protectedHeader).sign(privateKey);
+    return (await new SignJWT(payload).setProtectedHeader(protectedHeader).sign(privateKey)).split('.').pop();
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt-vc",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
-        "@meeco/sd-jwt": "^0.0.2"
+        "@meeco/sd-jwt": "^0.0.3"
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@meeco/sd-jwt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@meeco/sd-jwt/-/sd-jwt-0.0.2.tgz",
-      "integrity": "sha512-Ie0vcl+DIamlcJ3iyzylJRDetqJ4B0nyilSvrCYSmZBtcs7djZbhnSI9xVn7uktE1fOPJTVh6wLLh06B2wUVSA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@meeco/sd-jwt/-/sd-jwt-0.0.3.tgz",
+      "integrity": "sha512-r8T/W5zXIvGSg6QIWgTIUU9fwXAJwJrutb4m+fbpkSGPwAPWQHzYvzaZRRe4wcezhxSpAqodOd4KsYc+swbp0w==",
       "engines": {
         "node": ">=18",
         "npm": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "SD-JWT VC implementation in typescript",
   "scripts": {
     "build": "tsc",
@@ -64,6 +64,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@meeco/sd-jwt": "^0.0.2"
+    "@meeco/sd-jwt": "^0.0.3"
   }
 }

--- a/src/holder.ts
+++ b/src/holder.ts
@@ -1,4 +1,4 @@
-import { Disclosure, JWK, KeyBindingVerifier, decodeJWT, decodeSDJWT } from '@meeco/sd-jwt';
+import { Disclosure, JWK, KeyBindingVerifier, base64encode, decodeJWT, decodeSDJWT } from '@meeco/sd-jwt';
 import { CreateSDJWTPayload, JWT, PresentSDJWTPayload, SD_JWT_FORMAT_SEPARATOR, SignerConfig } from './types.js';
 import { isValidUrl } from './util.js';
 
@@ -45,7 +45,14 @@ export class Holder {
         iat: Date.now(),
       };
 
-      const jwt = await this.signer.callback(protectedHeader, presentSDJWTPayload);
+      const signature: string = await this.signer.callback(protectedHeader, presentSDJWTPayload);
+
+      const jwt: string = [
+        base64encode(JSON.stringify(protectedHeader)),
+        base64encode(JSON.stringify(presentSDJWTPayload)),
+        signature,
+      ].join('.');
+
       return { keyBindingJWT: jwt, nonce };
     } catch (error: any) {
       throw new Error(`Failed to get Key Binding JWT: ${error.message}`);

--- a/src/test-utils/helpers.ts
+++ b/src/test-utils/helpers.ts
@@ -5,8 +5,8 @@ import { NonceGenerator } from '../types';
 import { defaultHashAlgorithm, supportedAlgorithm } from '../util';
 
 export function signerCallbackFn(privateKey: Uint8Array | KeyLike): Signer {
-  return (protectedHeader: JWTHeaderParameters, payload: JWTPayload): Promise<string> => {
-    return new SignJWT(payload).setProtectedHeader(protectedHeader).sign(privateKey);
+  return async (protectedHeader: JWTHeaderParameters, payload: JWTPayload): Promise<string> => {
+    return (await new SignJWT(payload).setProtectedHeader(protectedHeader).sign(privateKey)).split('.').pop();
   };
 }
 


### PR DESCRIPTION
@vijayshiyani I made changes that expect the signer to return only the signature

this is inline with `did-jwt-vc` and `did-jwt` libs.
example: `EdDSASigner`