### PR TITLE
adding validation for JWT Reserved Claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.8 - 2023-12-08
+
+- Added validation that ensures JWT reserved claim keys are not present in both the claims and the disclosure frame.
+
 ## 0.0.7 - 2023-12-04
 
 ### Updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt-vc",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "@meeco/sd-jwt": "^0.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "SD-JWT VC implementation in typescript",
   "scripts": {
     "build": "tsc",

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -335,17 +335,23 @@ describe('Issuer', () => {
 
   describe('validateSDVCClaimsDisclosureFrame', () => {
     it('should not throw an error if sdVCClaimsDisclosureFrame is not provided', () => {
-      expect(() => issuer.validateSDVCClaimsDisclosureFrame(undefined)).not.toThrow();
+      const result = issuer.validateSDVCClaimsDisclosureFrame(undefined);
+      expect(() => result).not.toThrow();
+      expect(result).toBeUndefined();
     });
 
     it('should not throw an error if sdVCClaimsDisclosureFrame is provided but _sd is not present', () => {
       const frame = {};
-      expect(() => issuer.validateSDVCClaimsDisclosureFrame(frame)).not.toThrow();
+      const result = issuer.validateSDVCClaimsDisclosureFrame(frame);
+      expect(() => result).not.toThrow();
+      expect(result).toBeUndefined();
     });
 
     it('should not throw an error if sdVCClaimsDisclosureFrame is provided and _sd is an array but contains no reserved JWT payload keys', () => {
       const frame = { _sd: ['key1', 'key2'] };
-      expect(() => issuer.validateSDVCClaimsDisclosureFrame(frame)).not.toThrow();
+      const result = issuer.validateSDVCClaimsDisclosureFrame(frame);
+      expect(() => result).not.toThrow();
+      expect(result).toBeUndefined();
     });
 
     it('should throw an error if sdVCClaimsDisclosureFrame is provided and _sd is an array that contains a reserved JWT payload key', () => {

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -3,7 +3,14 @@ import { generateKeyPair } from 'jose';
 import { DisclosureFrame, decodeDisclosure, decodeJWT } from '@meeco/sd-jwt';
 import { Issuer } from './issuer';
 import { hasherCallbackFn, signerCallbackFn } from './test-utils/helpers';
-import { CreateSDJWTPayload, HasherConfig, SD_JWT_FORMAT_SEPARATOR, SignerConfig, VCClaims } from './types';
+import {
+  CreateSDJWTPayload,
+  HasherConfig,
+  ReservedJWTClaimKeys,
+  SD_JWT_FORMAT_SEPARATOR,
+  SignerConfig,
+  VCClaims,
+} from './types';
 import { supportedAlgorithm } from './util';
 
 describe('Issuer', () => {
@@ -301,25 +308,51 @@ describe('Issuer', () => {
       );
     });
 
-    it('should throw an error if status is not an object', () => {
-      const claims = {
-        type: 'VerifiableCredential',
-        status: 'invalid-status',
-      };
+    it('should throw an error if claims is not an object', () => {
+      expect(() => issuer.validateVCClaims('not an object' as any)).toThrow(
+        'Payload claims is required and must be an object',
+      );
+    });
 
-      expect(() => issuer.validateVCClaims(claims as any)).toThrowError('Payload status must be an object');
+    it('should throw an error if claims contains a reserved JWT payload key', () => {
+      const claims = { [ReservedJWTClaimKeys[0]]: 'value' };
+      expect(() => issuer.validateVCClaims(claims)).toThrow(
+        `Claim contains reserved JWTPayload key: ${ReservedJWTClaimKeys[0]}`,
+      );
     });
 
     it('should not throw an error if all properties are valid', () => {
       const claims = {
-        type: 'VerifiableCredential',
-        status: {
-          idx: 'statusIndex',
-          uri: 'https://valid.status.url',
+        person: {
+          name: 'test person',
+          age: 25,
         },
       };
 
       expect(() => issuer.validateVCClaims(claims)).not.toThrow();
+    });
+  });
+
+  describe('validateSDVCClaimsDisclosureFrame', () => {
+    it('should not throw an error if sdVCClaimsDisclosureFrame is not provided', () => {
+      expect(() => issuer.validateSDVCClaimsDisclosureFrame(undefined)).not.toThrow();
+    });
+
+    it('should not throw an error if sdVCClaimsDisclosureFrame is provided but _sd is not present', () => {
+      const frame = {};
+      expect(() => issuer.validateSDVCClaimsDisclosureFrame(frame)).not.toThrow();
+    });
+
+    it('should not throw an error if sdVCClaimsDisclosureFrame is provided and _sd is an array but contains no reserved JWT payload keys', () => {
+      const frame = { _sd: ['key1', 'key2'] };
+      expect(() => issuer.validateSDVCClaimsDisclosureFrame(frame)).not.toThrow();
+    });
+
+    it('should throw an error if sdVCClaimsDisclosureFrame is provided and _sd is an array that contains a reserved JWT payload key', () => {
+      const frame = { _sd: [ReservedJWTClaimKeys[0]] };
+      expect(() => issuer.validateSDVCClaimsDisclosureFrame(frame)).toThrow(
+        `Disclosure frame contains reserved JWTPayload key: ${ReservedJWTClaimKeys[0]}`,
+      );
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,17 @@ export interface JSONWebKeySet {
 }
 
 export type NonceGenerator = (length?: number) => string;
+
+export type CreateSDJWTPayloadKeys = keyof CreateSDJWTPayload;
+export const ReservedJWTClaimKeys: CreateSDJWTPayloadKeys[] = [
+  'iss',
+  'iat',
+  'cnf',
+  'vct',
+  'status',
+  'jti',
+  'sub',
+  'aud',
+  'nbf',
+  'exp',
+];


### PR DESCRIPTION
Implemented validation for JWT Reserved Claims. 
This update ensures that reserved claim keys are not present in both the claims and the disclosure frame.