### PR TITLE
sd_hash missing in payload of Key Binding JWTRefactored code to support sd_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,16 +247,19 @@ function hasherCallbackFn(alg: string = defaultHashAlgorithm): Hasher {
   };
 }
 
-function kbVeriferCallbackFn(expectedAud: string, expectedNonce: string): KeyBindingVerifier {
+function kbVeriferCallbackFn(expectedAud: string, expectedNonce: string, expectedSdHash: string): KeyBindingVerifier {
   return async (kbjwt: string, holderJWK: JWK) => {
     const { header, payload } = decodeJWT(kbjwt);
 
-    if (expectedAud || expectedNonce) {
+    if (expectedAud || expectedNonce || expectedSdHash) {
       if (payload.aud !== expectedAud) {
         throw new SDJWTVCError('aud mismatch');
       }
       if (payload.nonce !== expectedNonce) {
         throw new SDJWTVCError('nonce mismatch');
+      }
+      if (payload.sd_hash !== expectedSdHash) {
+        throw new SDJWTVCError('sd_hash mismatch');
       }
     }
 
@@ -274,8 +277,8 @@ async function main() {
   const verifier = new Verifier();
   const { vcSDJWTWithkeyBindingJWT, nonce } = {
     vcSDJWTWithkeyBindingJWT:
-      'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~WyJNcEFKRDhBWVBQaEJhT0tNIiwibmFtZSIsInRlc3QgcGVyc29uIl0~WyJJbFl3RkV5WDlLSFVIU1NFIiwiYWdlIiwyNV0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL3ZhbGlkLnZlcmlmaWVyLnVybCIsIm5vbmNlIjoibklkQmJOZWdScUNYQmw4WU9rZlZkZz09IiwiaWF0IjoxNjk1NzgzOTgzMDQxfQ.YwgHkYEpCFRHny5L4KdnU_qARVHL2jAScodRqfF5UP50nbryqIl4i1OuaxuQKala_uYNT-e0D4xzghoxWE56SQ',
-    nonce: 'nIdBbNegRqCXBl8YOkfVdg==',
+      'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~WyJNcEFKRDhBWVBQaEJhT0tNIiwibmFtZSIsInRlc3QgcGVyc29uIl0~WyJJbFl3RkV5WDlLSFVIU1NFIiwiYWdlIiwyNV0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL3ZhbGlkLnZlcmlmaWVyLnVybCIsIm5vbmNlIjoibklkQmJOZ1JxQ1hCbDhZT2tmVmRnPT0iLCJzZF9oYXNoIjoiTHdvOXZaMHc5SlVkZFlNdEVrc3JVYWc4TnRtY05JNGdFT3JhbzVYT1R6SSIsImlhdCI6MTcwNzE0NzYxNjk3MX0._rdKs3oVlxu6rGtbiBxP69Ammlc4OV6IPvQa9EVI6JUis3Vf5xOofS7xkJDeM5Q8rg00_vQqyQ21eYapyvLMSA',
+    nonce: 'nIdBbNgRqCXBl8YOkfVdg==',
   };
 
   const issuerPubKey = await importJWK({
@@ -284,11 +287,18 @@ async function main() {
     kty: 'OKP',
   });
 
+ const vcSDJWTWithoutKeyBinding: string = vcSDJWTWithkeyBindingJWT.slice(
+    0,
+    vcSDJWTWithkeyBindingJWT.lastIndexOf('~') + 1,
+  );
+  const hasher: Hasher = hasherCallbackFn(defaultHashAlgorithm);
+  const sdJwtHash: string = hasher(vcSDJWTWithoutKeyBinding);
+
   const result = await verifier.verifyVCSDJWT(
     vcSDJWTWithkeyBindingJWT,
     verifierCallbackFn(issuerPubKey),
     hasherCallbackFn(defaultHashAlgorithm),
-    kbVeriferCallbackFn('https://valid.verifier.url', nonce),
+    kbVeriferCallbackFn('https://valid.verifier.url', nonce, sdJwtHash),
   );
   console.log(result);
 }

--- a/src/holder.spec.ts
+++ b/src/holder.spec.ts
@@ -3,7 +3,7 @@ import { generateKeyPair, importJWK } from 'jose';
 import { Holder } from './holder';
 import { keyBindingVerifierCallbackFn, signerCallbackFn } from './test-utils/helpers';
 import { SignerConfig } from './types';
-import { supportedAlgorithm } from './util';
+import { defaultHashAlgorithm, supportedAlgorithm } from './util';
 
 describe('Holder', () => {
   let holder: Holder;
@@ -39,7 +39,7 @@ describe('Holder', () => {
 
   it('should get KeyBindingJWT', async () => {
     const nonce = 'nIdBbNgRqCXBl8YOkfVdg==';
-    const { keyBindingJWT } = await holder.getKeyBindingJWT('https://valid.verifier.url', nonce);
+    const { keyBindingJWT } = await holder.getKeyBindingJWT('https://valid.verifier.url', nonce, defaultHashAlgorithm);
 
     expect(keyBindingJWT).toBeDefined();
     expect(typeof keyBindingJWT).toBe('string');
@@ -100,6 +100,7 @@ describe('Holder', () => {
 
     expect(payload.aud).toEqual('https://valid.verifier.url');
     expect(payload.nonce).toEqual(nonceFromVerifier);
+    expect(payload.sd_hash).toBeDefined();
 
     expect(signature).toBeDefined();
   });
@@ -116,7 +117,7 @@ describe('Holder', () => {
         },
       ];
       const expected =
-        'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~WyJNcEFKRDhBWVBQaEJhT0tNIiwibmFtZSIsInRlc3QgcGVyc29uIl0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL3ZhbGlkLnZlcmlmaWVyLnVybCIsIm5vbmNlIjoibklkQmJOZWdScUNYQmw4WU9rZlZkZz09IiwiaWF0IjoxNjk1NzgzOTgzMDQxfQ.YwgHkYEpCFRHny5L4KdnU_qARVHL2jAScodRqfF5UP50nbryqIl4i1OuaxuQKala_uYNT-e0D4xzghoxWE56SQ';
+        'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~WyJNcEFKRDhBWVBQaEJhT0tNIiwibmFtZSIsInRlc3QgcGVyc29uIl0~';
       const result = holder.revealDisclosures(sdJWT, disclosedList);
       expect(result).toEqual(expected);
     });
@@ -139,7 +140,7 @@ describe('Holder', () => {
         'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~WyJNcEFKRDhBWVBQaEJhT0tNIiwibmFtZSIsInRlc3QgcGVyc29uIl0~WyJJbFl3RkV5WDlLSFVIU1NFIiwiYWdlIiwyNV0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL3ZhbGlkLnZlcmlmaWVyLnVybCIsIm5vbmNlIjoibklkQmJOZWdScUNYQmw4WU9rZlZkZz09IiwiaWF0IjoxNjk1NzgzOTgzMDQxfQ.YwgHkYEpCFRHny5L4KdnU_qARVHL2jAScodRqfF5UP50nbryqIl4i1OuaxuQKala_uYNT-e0D4xzghoxWE56SQ';
       const disclosedList = [];
       const expected =
-        'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL3ZhbGlkLnZlcmlmaWVyLnVybCIsIm5vbmNlIjoibklkQmJOZWdScUNYQmw4WU9rZlZkZz09IiwiaWF0IjoxNjk1NzgzOTgzMDQxfQ.YwgHkYEpCFRHny5L4KdnU_qARVHL2jAScodRqfF5UP50nbryqIl4i1OuaxuQKala_uYNT-e0D4xzghoxWE56SQ';
+        'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~';
       const result = holder.revealDisclosures(sdJWT, disclosedList);
       expect(result).toEqual(expected);
     });

--- a/src/holder.ts
+++ b/src/holder.ts
@@ -105,9 +105,10 @@ export class Holder {
     }
 
     const hasher: Hasher = hasherCallbackFn(sdHashAlgorithm);
-    const sdJwtHash: string = hasher(sdJWT);
 
     const vcSDJWTWithRevealedDisclosures = this.revealDisclosures(sdJWT, disclosedList);
+
+    const sdJwtHash: string = hasher(vcSDJWTWithRevealedDisclosures);
 
     const { keyBindingJWT } = await this.getKeyBindingJWT(options.audience, options.nonce, sdJwtHash);
 

--- a/src/holder.ts
+++ b/src/holder.ts
@@ -148,6 +148,10 @@ export class Holder {
       return disclosedList.some((disclosed) => disclosed.disclosure === disclosure.disclosure);
     });
 
+    if (revealedDisclosures.length === 0) {
+      return `${compactJWT}${SD_JWT_FORMAT_SEPARATOR}`;
+    }
+
     const revealedDisclosuresEncoded = revealedDisclosures
       .map((disclosure) => disclosure.disclosure)
       .join(SD_JWT_FORMAT_SEPARATOR);

--- a/src/test-utils/helpers.ts
+++ b/src/test-utils/helpers.ts
@@ -11,16 +11,23 @@ export function signerCallbackFn(privateKey: Uint8Array | KeyLike): Signer {
   };
 }
 
-export function kbVeriferCallbackFn(expectedAud: string, expectedNonce: string): KeyBindingVerifier {
+export function kbVeriferCallbackFn(
+  expectedAud: string,
+  expectedNonce: string,
+  expectedSdHash: string,
+): KeyBindingVerifier {
   return async (kbjwt: string, holderJWK: JWK) => {
     const { header, payload } = decodeJWT(kbjwt);
 
-    if (expectedAud || expectedNonce) {
+    if (expectedAud || expectedNonce || expectedSdHash) {
       if (payload.aud !== expectedAud) {
         throw new SDJWTVCError('aud mismatch');
       }
       if (payload.nonce !== expectedNonce) {
         throw new SDJWTVCError('nonce mismatch');
+      }
+      if (payload.sd_hash !== expectedSdHash) {
+        throw new SDJWTVCError('sd_hash mismatch');
       }
     }
 

--- a/src/verifier.spec.ts
+++ b/src/verifier.spec.ts
@@ -2,6 +2,7 @@ import { importJWK } from 'jose';
 import { hasherCallbackFn, kbVeriferCallbackFn, verifierCallbackFn } from './test-utils/helpers';
 import { defaultHashAlgorithm } from './util';
 import { Verifier } from './verifier';
+import { Hasher } from '@meeco/sd-jwt';
 
 describe('Verifier', () => {
   let verifier: Verifier;
@@ -34,8 +35,8 @@ describe('Verifier', () => {
 
       const { vcSDJWTWithkeyBindingJWT, nonce } = {
         vcSDJWTWithkeyBindingJWT:
-          'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~WyJNcEFKRDhBWVBQaEJhT0tNIiwibmFtZSIsInRlc3QgcGVyc29uIl0~WyJJbFl3RkV5WDlLSFVIU1NFIiwiYWdlIiwyNV0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL3ZhbGlkLnZlcmlmaWVyLnVybCIsIm5vbmNlIjoibklkQmJOZWdScUNYQmw4WU9rZlZkZz09IiwiaWF0IjoxNjk1NzgzOTgzMDQxfQ.YwgHkYEpCFRHny5L4KdnU_qARVHL2jAScodRqfF5UP50nbryqIl4i1OuaxuQKala_uYNT-e0D4xzghoxWE56SQ',
-        nonce: 'nIdBbNegRqCXBl8YOkfVdg==',
+          'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE2OTU2ODI0MDg4NTcsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJ4Ijoickg3T2xtSHFkcE5PUjJQMjhTN3Vyb3hBR2sxMzIxTnNneGdwNHhfUGlldyIsInkiOiJXR0NPSm1BN25Uc1hQOUF6X210TnkwalQ3bWRNQ21TdFRmU080RGpSc1NnIiwiY3J2IjoiUC0yNTYifX0sImlzcyI6Imh0dHBzOi8vdmFsaWQuaXNzdWVyLnVybCIsInR5cGUiOiJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsInN0YXR1cyI6eyJpZHgiOiJzdGF0dXNJbmRleCIsInVyaSI6Imh0dHBzOi8vdmFsaWQuc3RhdHVzLnVybCJ9LCJwZXJzb24iOnsiX3NkIjpbImNRbzBUTTdfZEZXb2djcUpUTlJPeGJUTnI1T0VaakNWUHNlVVBVN0ROa3ciLCJZY3BHVTNKTDFvS0NoOXY4VjAwQmxWLTQtZTFWN1h0U1BvYUtra2RuZG1BIl19fQ.iPmq7Fv-pxS5NgTpH5xUarz6uG1MIphHy4q5mWdLBJRfp6ER2eG306WeHhCBoDzrYURgWZiEySnTEBDbD2HfCA~WyJNcEFKRDhBWVBQaEJhT0tNIiwibmFtZSIsInRlc3QgcGVyc29uIl0~WyJJbFl3RkV5WDlLSFVIU1NFIiwiYWdlIiwyNV0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL3ZhbGlkLnZlcmlmaWVyLnVybCIsIm5vbmNlIjoibklkQmJOZ1JxQ1hCbDhZT2tmVmRnPT0iLCJzZF9oYXNoIjoiTHdvOXZaMHc5SlVkZFlNdEVrc3JVYWc4TnRtY05JNGdFT3JhbzVYT1R6SSIsImlhdCI6MTcwNzE0NzYxNjk3MX0._rdKs3oVlxu6rGtbiBxP69Ammlc4OV6IPvQa9EVI6JUis3Vf5xOofS7xkJDeM5Q8rg00_vQqyQ21eYapyvLMSA',
+        nonce: 'nIdBbNgRqCXBl8YOkfVdg==',
       };
 
       const issuerPubKey = await importJWK({
@@ -44,11 +45,18 @@ describe('Verifier', () => {
         kty: 'OKP',
       });
 
+      const vcSDJWTWithoutKeyBinding: string = vcSDJWTWithkeyBindingJWT.slice(
+        0,
+        vcSDJWTWithkeyBindingJWT.lastIndexOf('~') + 1,
+      );
+      const hasher: Hasher = hasherCallbackFn(defaultHashAlgorithm);
+      const sdJwtHash: string = hasher(vcSDJWTWithoutKeyBinding);
+
       const result = await verifier.verifyVCSDJWT(
         vcSDJWTWithkeyBindingJWT,
         verifierCallbackFn(issuerPubKey),
         hasherCallbackFn(defaultHashAlgorithm),
-        kbVeriferCallbackFn('https://valid.verifier.url', nonce),
+        kbVeriferCallbackFn('https://valid.verifier.url', nonce, sdJwtHash),
       );
       expect(result).toEqual(claims);
     });
@@ -117,14 +125,21 @@ describe('Verifier', () => {
         kty: 'OKP',
       });
 
+      const vcSDJWTWithoutKeyBinding: string = vcSDJWTWithkeyBindingJWT.slice(
+        0,
+        vcSDJWTWithkeyBindingJWT.lastIndexOf('~') + 1,
+      );
+      const hasher: Hasher = hasherCallbackFn(defaultHashAlgorithm);
+      const sdJwtHash: string = hasher(vcSDJWTWithoutKeyBinding);
+
       await expect(() =>
         verifier.verifyVCSDJWT(
           vcSDJWTWithkeyBindingJWT,
           verifierCallbackFn(issuerPubKey),
           hasherCallbackFn(defaultHashAlgorithm),
-          kbVeriferCallbackFn('https://valid.verifier.url', nonce),
+          kbVeriferCallbackFn('https://valid.verifier.url', nonce, sdJwtHash),
         ),
-      ).rejects.toThrowError('Missing aud, nonce or iat in key binding JWT');
+      ).rejects.toThrowError('Missing aud, nonce, iat or sd_hash in key binding JWT');
     });
   });
 });

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -35,9 +35,9 @@ export class Verifier {
 
       const decodedKeyBindingJWT = decodeJWT(keyBindingJWT);
       const { payload } = decodedKeyBindingJWT;
-      const { aud, nonce, iat } = payload;
-      if (!aud || !nonce || !iat) {
-        throw new SDJWTVCError('Missing aud, nonce or iat in key binding JWT');
+      const { aud, nonce, iat, sd_hash } = payload;
+      if (!aud || !nonce || !iat || !sd_hash) {
+        throw new SDJWTVCError('Missing aud, nonce, iat or sd_hash in key binding JWT');
       }
     }
 


### PR DESCRIPTION
According to spec [Key Binding for SD-JWT-VC](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-01.html#name-key-binding-jwt), 

> the Key Binding JWT MUST adhere to the rules defined in Section 5.3 of [SD-JWT spec](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#section-5.3-3.2.1)

This means, that the sd_hash claim has to be included in the payload of the Key Binding JWT. 
