### PR TITLE
Remove Holder dependency on crypto library. Hasher function resolver …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 - 2024-02-09
+
+### Changed
+
+- `Holder` class added with addition parameter to configure hasher
+- Key binding JWT includes `sd_hash` payload attribute
+
 ## 0.1.0 - 2024-02-05
+
+### Added
 
 - allow additional header input for the sd-jwt vc creation
 
 ## 0.0.9 - 2024-02-01
+
+### Fixed
 
 - update `sd-jwt` dependency
 - bugfix: ESM imports
 
 ## 0.0.8 - 2023-12-08
 
+### Added
+
 - Added validation that ensures JWT reserved claim keys are not present in both the claims and the disclosure frame.
 
 ## 0.0.7 - 2023-12-04
 
-### Updates
+### Changed
 
 - The `CreateSDJWTPayload` type now requires `vct` fields in the payload.
 - The optional `status` field has been moved from `VCClaims` to `CreateSDJWTPayload` type.
 - Demo scripts have been updated.
 
-### Removals
+### Removed
 
 - Removed the `VCClaimsWithVCDataModel` type, which was specific to the w3c data model, from the VCSDJWT creation process. This change allows for the creation of a VCSDJWT with any data model.
 

--- a/README.md
+++ b/README.md
@@ -126,12 +126,22 @@ This is a TypeScript class that represents a holder of Verifiable Credentials (V
 
 #### Usage
 
-To use the Holder class, you need to create an instance of it by passing in a Holder Signer configuration object. Here's an example:
+To use the Holder class, you need to create an instance of it by passing in a Holder Signer configuration object and Hasher function resolver. Here's an example:
 
 ```typescript
-import { KeyBindingVerifier, Signer, decodeJWT } from '@meeco/sd-jwt';
+import { KeyBindingVerifier, Signer, decodeJWT, base64encode } from '@meeco/sd-jwt';
 import { JWK, JWTHeaderParameters, JWTPayload, KeyLike, SignJWT, importJWK, jwtVerify } from 'jose';
 import { Holder, SignerConfig, supportedAlgorithm } from '@meeco/sd-jwt-vc';
+import { createHash } from 'crypto';
+
+const hasherFnResolver = (alg: string) => {
+  const hasher = (data: string): string => {
+    const digest = createHash(alg).update(data).digest();
+    return base64encode(digest);
+  }
+
+  return Promise.resolve(hasher);
+}
 
 const signerCallbackFn = function (privateKey: Uint8Array | KeyLike): Signer {
   return (protectedHeader: JWTHeaderParameters, payload: JWTPayload): Promise<string> => {
@@ -160,7 +170,7 @@ async function main() {
     alg: supportedAlgorithm.ES256,
     callback: signerCallbackFn(pk),
   };
-  const holder = new Holder(signer);
+  const holder = new Holder(signer, hasherFnResolver);
 }
 
 main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt-vc",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@meeco/sd-jwt": "^0.0.4"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SD-JWT VC implementation in typescript",
   "scripts": {
     "build": "tsc",

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -103,13 +103,13 @@ describe('Issuer', () => {
   describe('Issuer', () => {
     describe('constructor', () => {
       it('should throw an error if signer callback is not provided', () => {
-        expect(() => new Issuer({ alg: supportedAlgorithm.ES256, callback: undefined }, undefined)).toThrowError(
+        expect(() => new Issuer({ alg: supportedAlgorithm.ES256, callback: undefined }, undefined)).toThrow(
           'Signer function is required',
         );
       });
 
       it('should throw an error if signer alg is not provided', () => {
-        expect(() => new Issuer({ alg: undefined, callback: () => Promise.resolve('') }, undefined)).toThrowError(
+        expect(() => new Issuer({ alg: undefined, callback: () => Promise.resolve('') }, undefined)).toThrow(
           'algo used for Signer function is required',
         );
       });
@@ -121,7 +121,7 @@ describe('Issuer', () => {
               { callback: () => Promise.resolve(''), alg: supportedAlgorithm.ES256 },
               { alg: 'SHA256', callback: undefined },
             ),
-        ).toThrowError('Hasher function is required');
+        ).toThrow('Hasher function is required');
       });
 
       it('should throw an error if hasher alg is not provided', () => {
@@ -131,7 +131,7 @@ describe('Issuer', () => {
               { callback: () => Promise.resolve(''), alg: supportedAlgorithm.ES256 },
               { callback: () => '', alg: undefined },
             ),
-        ).toThrowError('algo used for Hasher function is required');
+        ).toThrow('algo used for Hasher function is required');
       });
 
       it('should create an instance of Issuer if all required parameters are provided', () => {
@@ -154,7 +154,7 @@ describe('Issuer', () => {
         },
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrowError(
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrow(
         'Issuer iss (issuer) is required and must be a valid URL',
       );
     });
@@ -168,7 +168,7 @@ describe('Issuer', () => {
         iss: 'invalid-url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrowError(
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrow(
         'Issuer iss (issuer) is required and must be a valid URL',
       );
     });
@@ -181,7 +181,7 @@ describe('Issuer', () => {
         iss: 'https://valid.issuer.url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrowError(
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrow(
         'Payload iat (Issued at - seconds since Unix epoch) is required and must be a number',
       );
     });
@@ -195,7 +195,7 @@ describe('Issuer', () => {
         iss: 'https://valid.issuer.url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload as any)).toThrowError(
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload as any)).toThrow(
         'Payload iat (Issued at - seconds since Unix epoch) is required and must be a number',
       );
     });
@@ -206,7 +206,7 @@ describe('Issuer', () => {
         iss: 'https://valid.issuer.url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrowError(
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrow(
         'Payload cnf is required and must be a JWK format',
       );
     });
@@ -218,7 +218,7 @@ describe('Issuer', () => {
         iss: 'https://valid.issuer.url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload as any)).toThrowError(
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload as any)).toThrow(
         'Payload cnf is required and must be a JWK format',
       );
     });
@@ -232,7 +232,7 @@ describe('Issuer', () => {
         iss: 'https://valid.issuer.url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload as any)).toThrowError(
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload as any)).toThrow(
         'Payload cnf.jwk must be valid JWK format',
       );
     });
@@ -250,7 +250,7 @@ describe('Issuer', () => {
         iss: 'https://valid.issuer.url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrowError('Payload cnf.jwk must be valid JWK format');
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrow('Payload cnf.jwk must be valid JWK format');
     });
 
     it('should throw an error if vct is not a valid String', () => {
@@ -268,7 +268,7 @@ describe('Issuer', () => {
         vct: 123,
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrowError('vct value MUST be a case-sensitive string');
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrow('vct value MUST be a case-sensitive string');
     });
 
     it('should throw an error if vct is not a valid url', () => {
@@ -286,7 +286,7 @@ describe('Issuer', () => {
         vct: 'httpinvalid-url',
       };
 
-      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrowError('vct value MUST be a valid URL');
+      expect(() => issuer.validateSDJWTPayload(sdJWTPayload)).toThrow('vct value MUST be a valid URL');
     });
 
     it('should not throw an error if all properties are valid', () => {
@@ -312,9 +312,7 @@ describe('Issuer', () => {
     it('should throw an error if claims is missing', () => {
       const claims = undefined;
 
-      expect(() => issuer.validateVCClaims(claims as any)).toThrowError(
-        'Payload claims is required and must be an object',
-      );
+      expect(() => issuer.validateVCClaims(claims as any)).toThrow('Payload claims is required and must be an object');
     });
 
     it('should throw an error if claims is not an object', () => {

--- a/src/issuer.ts
+++ b/src/issuer.ts
@@ -35,7 +35,6 @@ export class Issuer {
     this.hasher = hasher;
   }
 
-  // write getter for signer and hasher
   get getSigner() {
     return this.signer;
   }

--- a/src/verifier.spec.ts
+++ b/src/verifier.spec.ts
@@ -1,8 +1,8 @@
+import { Hasher } from '@meeco/sd-jwt';
 import { importJWK } from 'jose';
 import { hasherCallbackFn, kbVeriferCallbackFn, verifierCallbackFn } from './test-utils/helpers';
 import { defaultHashAlgorithm } from './util';
 import { Verifier } from './verifier';
-import { Hasher } from '@meeco/sd-jwt';
 
 describe('Verifier', () => {
   let verifier: Verifier;
@@ -110,7 +110,7 @@ describe('Verifier', () => {
           verifierCallbackFn(issuerPubKey),
           hasherCallbackFn(defaultHashAlgorithm),
         ),
-      ).rejects.toThrowError('Missing key binding verifier callback function');
+      ).rejects.toThrow('Missing key binding verifier callback function');
     });
 
     it('should throw an error if keybinding jwt do not have aud, nonce or iat', async () => {
@@ -139,7 +139,7 @@ describe('Verifier', () => {
           hasherCallbackFn(defaultHashAlgorithm),
           kbVeriferCallbackFn('https://valid.verifier.url', nonce, sdJwtHash),
         ),
-      ).rejects.toThrowError('Missing aud, nonce, iat or sd_hash in key binding JWT');
+      ).rejects.toThrow('Missing aud, nonce, iat or sd_hash in key binding JWT');
     });
   });
 });


### PR DESCRIPTION
Remove Holder dependency on crypto library. 
Hasher function resolver parameter introduced.

Jest: replace deprecated `toThrowError` with `toThrow`.

Format `CHANGELOG.md` file.

Bump up version to `0.2.0`.