### PR TITLE
feat: Add support for vctm header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project (loosely) adheres to [Semantic Versioning](https://semver.org/s
 - The `typ` header for issued SD-JWT VCs is now `dc+sd-jwt` as per [draft-08](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#section-3.2.1)
 - The `Verifier` will accept both `vc+sd-jwt` and `dc+sd-jwt`.
 
+### Removed
+
+- Removed deprecated `createVCSDJWT` method from the `Issuer` class. Use `createSignedVCSDJWT` instead.
+
 ## 1.3.0 - 2024-10-07
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project (loosely) adheres to [Semantic Versioning](https://semver.org/s
 
 ## 2.0.0 - 2025-XX-XX
 
+### Added
+
+- Support embedding Type Metadata documents in the JWS unprotected header via the `vctm` parameter, as per [SD-JWT VC Spec Section 6.3.5](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-05.html#section-6.3.5).
+
 ### Changed
 
 - The `typ` header for issued SD-JWT VCs is now `dc+sd-jwt` as per [draft-08](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#section-3.2.1)

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -69,7 +69,13 @@ describe('Issuer', () => {
       ],
     };
 
-    const VCSDJwt = await issuer.createVCSDJWT(vcClaims, payload, sdVCClaimsDisclosureFrame, undefined, sdVCHeader);
+    const VCSDJwt = await issuer.createSignedVCSDJWT({
+      vcClaims,
+      sdJWTPayload: payload,
+      sdVCClaimsDisclosureFrame,
+      saltGenerator: undefined,
+      sdJWTHeader: sdVCHeader,
+    });
 
     expect(VCSDJwt).toBeDefined();
     expect(typeof VCSDJwt).toBe('string');

--- a/src/issuer.ts
+++ b/src/issuer.ts
@@ -1,21 +1,6 @@
-import {
-  DisclosureFrame,
-  JWTHeaderParameters,
-  SDJWTPayload,
-  SaltGenerator,
-  base64encode,
-  issueSDJWT,
-} from '@meeco/sd-jwt';
+import { DisclosureFrame, JWTHeaderParameters, SDJWTPayload, base64encode, issueSDJWT } from '@meeco/sd-jwt';
 import { SDJWTVCError } from './errors.js';
-import {
-  CreateSDJWTPayload,
-  CreateSignedJWTOpts,
-  HasherConfig,
-  JWT,
-  ReservedJWTClaimKeys,
-  SignerConfig,
-  VCClaims,
-} from './types.js';
+import { CreateSignedJWTOpts, HasherConfig, JWT, ReservedJWTClaimKeys, SignerConfig, VCClaims } from './types.js';
 import { ValidTypValues, isValidUrl } from './util.js';
 
 export class Issuer {
@@ -47,27 +32,6 @@ export class Issuer {
   }
   get getHasher() {
     return this.hasher;
-  }
-
-  /**
-   * Creates a VC SD-JWT.
-   * @deprecated This method will be removed in the next version. Use `createSignedVCSDJWT` instead.
-   * @param claims The VC claims.
-   * @param sdJWTPayload The SD-JWT payload.
-   * @param sdVCClaimsDisclosureFrame The SD-VC claims disclosure frame.
-   * @param saltGenerator The salt generator.
-   * @param sdJWTHeader additional header parameters
-   * @throws An error if the VC SD-JWT cannot be created.
-   * @returns The VC SD-JWT.
-   */
-  async createVCSDJWT(
-    vcClaims: VCClaims,
-    sdJWTPayload: CreateSDJWTPayload,
-    sdVCClaimsDisclosureFrame: DisclosureFrame = {},
-    saltGenerator?: SaltGenerator,
-    sdJWTHeader?: Omit<JWTHeaderParameters, 'typ' | 'alg'>,
-  ): Promise<JWT> {
-    return this.createSignedVCSDJWT({ vcClaims, sdJWTPayload, sdVCClaimsDisclosureFrame, saltGenerator, sdJWTHeader });
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface CreateSignedJWTOpts {
   sdVCClaimsDisclosureFrame?: DisclosureFrame;
   saltGenerator?: SaltGenerator;
   sdJWTHeader?: Omit<JWTHeaderParameters, 'typ' | 'alg'>;
+  typeMetadataGlueDocuments?: Array<Record<string, any> | string>;
 }
 
 export interface PresentSDJWTPayload extends JWTPayload {


### PR DESCRIPTION
Added support for embedding Type Metadata documents in the JWS unprotected header via the vctm parameter (as per [SD-JWT VC Spec Section 6.3.5](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-05.html#section-6.3.5).