### PR TITLE
feat: Implement Type Metadata utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.0.0 - 2025-XX-XX
+## 2.0.0 - 2025-05-28
+
+### Added
+
+- Extracts and decodes Type Metadata documents embedded in the `vctm` unprotected header.
+- Fetches and optionally verifies Type Metadata from a URL specified in the `vct` claim.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project (loosely) adheres to [Semantic Versioning](https://semver.org/s
 
 ### Added
 
-- Util function to extracts and decodes Type Metadata documents embedded in the `vctm` unprotected header.
-- Util function to fetche and optionally verifies Type Metadata from a URL specified in the `vct` claim.
+- `extractEmbeddedTypeMetadata()` utility function to extract and decode Type Metadata documents embedded in the `vctm` unprotected header of SD-JWT VCs
+- `fetchTypeMetadataFromUrl()` utility function to fetch and optionally verify Type Metadata from URLs specified in the `vct` claim, with integrity validation support
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project (loosely) adheres to [Semantic Versioning](https://semver.org/s
 
 ### Added
 
-- Extracts and decodes Type Metadata documents embedded in the `vctm` unprotected header.
-- Fetches and optionally verifies Type Metadata from a URL specified in the `vct` claim.
+- Util function to extracts and decodes Type Metadata documents embedded in the `vctm` unprotected header.
+- Util function to fetche and optionally verifies Type Metadata from a URL specified in the `vct` claim.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This is an implementation of [SD-JWT VC (I-D version 01)](https://drafts.oauth.net/oauth-sd-jwt-vc/draft-ietf-oauth-sd-jwt-vc.html) in Typescript. It provides a higher-level interface on top of the [@meeco/sd-jwt](https://github.com/Meeco/sd-jwt) library to create the compliant SD-JWT VCs.
 
-**Note on `typ` header (as of v2.0.0 / Unreleased):**
+**Note on `typ` header (as of v2.0.0):**
 
 - The `typ` header for issued SD-JWT VCs is `dc+sd-jwt`.
 - The `Verifier` will accept both `vc+sd-jwt` and `dc+sd-jwt`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,3 +78,28 @@ export const ReservedJWTClaimKeys: CreateSDJWTPayloadKeys[] = [
   'nbf',
   'exp',
 ];
+
+/**
+ * Represents the structure of a Type Metadata document as defined in the SD-JWT VC specification (Section 6.2).
+ */
+export interface TypeMetadata {
+  vct?: string;
+  name?: string;
+  description?: string;
+  extends?: string; // URI
+  display?: Array<Record<string, any>>;
+  claims?: Array<Record<string, any>>;
+  /**
+   * OPTIONAL. An embedded JSON Schema document describing the structure of the Verifiable Credential.
+   * MUST NOT be used if schema_uri is present.
+   */
+  schema?: Record<string, any>;
+  /**
+   * OPTIONAL. A URL pointing to a JSON Schema document.
+   * MUST NOT be used if schema is present.
+   */
+  schema_uri?: string;
+  'schema_uri#integrity'?: string;
+
+  [key: string]: any;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,14 @@ export interface TypeMetadata {
    * MUST NOT be used if schema is present.
    */
   schema_uri?: string;
+
+  /**
+   * OPTIONAL. integrity metadata for vct, extends, schema_uri, and similar URIs.
+   * Value MUST be an "integrity metadata" string per W3C.SRI.
+   */
   'schema_uri#integrity'?: string;
+  'vct#integrity'?: string;
+  'extends#integrity'?: string;
 
   [key: string]: any;
 }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,6 +1,12 @@
-import { JWK, decodeJWT } from '@meeco/sd-jwt';
+import { decodeJWT, JWK, Hasher as SDJWTHasher, SDJWTPayload } from '@meeco/sd-jwt';
+import * as crypto from 'crypto';
 import { SDJWTVCError } from './errors';
-import { getIssuerPublicKeyFromWellKnownURI } from './util';
+import {
+  extractEmbeddedTypeMetadata,
+  fetchTypeMetadataFromUrl,
+  getIssuerPublicKeyFromWellKnownURI,
+  isValidUrl,
+} from './util';
 
 describe('getIssuerPublicKeyFromIss', () => {
   const sdJwtVC =
@@ -292,5 +298,319 @@ describe('getIssuerPublicKeyFromIss', () => {
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(fetch).toHaveBeenCalledWith(jwtIssuerWellKnownUrl);
     expect(fetch).toHaveBeenCalledWith(jwtIssuerWellKnownFallbackUrl);
+  });
+});
+
+describe('extractEmbeddedTypeMetadata', () => {
+  it('should return null if vctm header is not present', () => {
+    const sdJwtVC = 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJ0ZXN0LWlzc3VlciJ9.c2lnbmF0dXJl'; // No vctm
+    expect(extractEmbeddedTypeMetadata(sdJwtVC)).toBeNull();
+  });
+
+  it('should return null for a malformed JWS header', () => {
+    const sdJwtVC = 'malformedJWS.payload.signature';
+    expect(extractEmbeddedTypeMetadata(sdJwtVC)).toBeNull();
+  });
+
+  it('should throw an error if vctm is present but not an array', () => {
+    // JWS with unprotected header: { "vctm": "not-an-array" }
+    // Header: eyJ2Y3RtIjoibm90LWFuLWFycmF5In0 (base64url of {"vctm":"not-an-array"})
+    const sdJwtVC = 'eyJ2Y3RtIjoibm90LWFuLWFycmF5In0.eyJpc3MiOiJ0ZXN0LWlzc3VlciJ9.c2lnbmF0dXJl';
+    expect(() => extractEmbeddedTypeMetadata(sdJwtVC)).toThrow(
+      new SDJWTVCError('vctm in unprotected header must be an array'),
+    );
+  });
+
+  it('should throw an error if vctm contains invalid base64url data', () => {
+    // JWS with unprotected header: { "vctm": ["invalid-b64url!"] }
+    // Header: eyJ2Y3RtIjpbImludmFsaWQtYjY0dXJsISJdfQ (base64url of {"vctm":["invalid-b64url!"]})
+    const sdJwtVC = 'eyJ2Y3RtIjpbImludmFsaWQtYjY0dXJsISJdfQ.eyJpc3MiOiJ0ZXN0LWlzc3VlciJ9.c2lnbmF0dXJl';
+    expect(() => extractEmbeddedTypeMetadata(sdJwtVC)).toThrow(SDJWTVCError);
+  });
+
+  it('should correctly decode and return type metadata documents', () => {
+    const doc1 = { type: 'doc1', data: 'test1' };
+    const doc2 = { type: 'doc2', data: 'test2' };
+    const encodedDoc1 = Buffer.from(JSON.stringify(doc1)).toString('base64url');
+    const encodedDoc2 = Buffer.from(JSON.stringify(doc2)).toString('base64url');
+    // Constructing the JWS with the vctm in the *unprotected* header part is tricky directly in a string literal
+    // as it's part of the signed JWS structure. For testing, we simulate a JWS where the
+    // unprotected header part (if it were separate, which it isn't in compact JWS) would contain vctm.
+    // The function `decodeProtectedHeader` correctly decodes the *first* part of a JWS (the protected header).
+    // If `vctm` is intended to be in an *unprotected* header, the `decodeJWT` from `@meeco/sd-jwt` might expose it differently,
+    // or the JWS needs to be constructed in a specific way (e.g., using General JWS JSON Serialization).
+    // For this test, we'll assume the `vctm` is part of the main JWS header, decodable by `decodeProtectedHeader`.
+    const headerWithVctm = { vctm: [encodedDoc1, encodedDoc2] };
+    const base64UrlEncodedHeader = Buffer.from(JSON.stringify(headerWithVctm)).toString('base64url');
+    const sdJwtVC = `${base64UrlEncodedHeader}.eyJpc3MiOiJ0ZXN0LWlzc3VlciJ9.c2lnbmF0dXJl`;
+
+    const result = extractEmbeddedTypeMetadata(sdJwtVC);
+    expect(result).toEqual([doc1, doc2]);
+  });
+
+  it('should return empty array if vctm is an empty array', () => {
+    // JWS with unprotected header: { "vctm": [] }
+    // Header: eyJ2Y3RtIjpbXX0 (base64url of {"vctm":[]})
+    const sdJwtVC = 'eyJ2Y3RtIjpbXX0.eyJpc3MiOiJ0ZXN0LWlzc3VlciJ9.c2lnbmF0dXJl';
+    const result = extractEmbeddedTypeMetadata(sdJwtVC);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('fetchTypeMetadataFromUrl', () => {
+  const mockPayloadBase: SDJWTPayload = {
+    iss: 'https://issuer.example.com',
+    sub: 'user123',
+    iat: Date.now(),
+    exp: Date.now() + 3600000,
+  };
+
+  const mockTypeMetadata = {
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential', 'CustomType'],
+    credentialSubject: {
+      degree: {
+        type: 'BachelorDegree',
+        name: 'Bachelor of Science and Arts',
+      },
+    },
+  };
+
+  // Define mockHasher as a synchronous function returning string
+  const mockHasher: SDJWTHasher = jest.fn((data: string): string => {
+    return crypto.createHash('sha256').update(data).digest('base64url');
+  });
+
+  beforeEach(() => {
+    // Resets all mocks, including their call counts
+    jest.resetAllMocks();
+    (global as any).fetch = jest.fn();
+  });
+
+  it('should return null if vct is not a string', async () => {
+    const payload = { ...mockPayloadBase, vct: 12345 as any };
+    const result = await fetchTypeMetadataFromUrl(payload);
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should return null if vct is not an HTTPS URL', async () => {
+    const payload = { ...mockPayloadBase, vct: 'http://example.com/metadata' };
+    const result = await fetchTypeMetadataFromUrl(payload);
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should return null if vct is not a valid URL', async () => {
+    const payload = { ...mockPayloadBase, vct: 'https://invalid url' }; // relies on util.isValidUrl
+    const result = await fetchTypeMetadataFromUrl(payload);
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should fetch and return type metadata for a valid vct URL', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const payload = { ...mockPayloadBase, vct: vctUrl };
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockTypeMetadata)),
+    });
+
+    const result = await fetchTypeMetadataFromUrl(payload);
+    expect(result).toEqual(mockTypeMetadata);
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should return null if fetching metadata fails (network error)', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const payload = { ...mockPayloadBase, vct: vctUrl };
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    const result = await fetchTypeMetadataFromUrl(payload);
+    expect(result).toBeNull();
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should return null if fetched content is not valid JSON', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const payload = { ...mockPayloadBase, vct: vctUrl };
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('this is not json'),
+    });
+
+    const result = await fetchTypeMetadataFromUrl(payload);
+    expect(result).toBeNull();
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should perform integrity check if vct#integrity and hasher are provided', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const rawContent = JSON.stringify(mockTypeMetadata);
+    const contentHash = mockHasher(rawContent); // mockHasher is sync now
+    const payload = { ...mockPayloadBase, vct: vctUrl, 'vct#integrity': contentHash };
+
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(rawContent),
+    });
+    (mockHasher as jest.Mock).mockClear(); // Clear calls from contentHash generation
+
+    const result = await fetchTypeMetadataFromUrl(payload, { hasher: mockHasher });
+    expect(result).toEqual(mockTypeMetadata);
+    expect(mockHasher).toHaveBeenCalledWith(rawContent);
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should perform integrity check with algorithm prefix in vct#integrity', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const rawContent = JSON.stringify(mockTypeMetadata);
+    const contentHash = mockHasher(rawContent); // mockHasher is sync
+    const integrityClaim = `sha256-${contentHash}`;
+    const payload = { ...mockPayloadBase, vct: vctUrl, 'vct#integrity': integrityClaim };
+
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(rawContent),
+    });
+    (mockHasher as jest.Mock).mockClear();
+
+    const result = await fetchTypeMetadataFromUrl(payload, { hasher: mockHasher });
+    expect(result).toEqual(mockTypeMetadata);
+    expect(mockHasher).toHaveBeenCalledWith(rawContent);
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should throw SDJWTVCError if integrity check fails', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const rawContent = JSON.stringify(mockTypeMetadata);
+    // mockHasher will produce a specific hash for rawContent.
+    // wrongHash is different, so the check should fail.
+    const wrongHash = 'totally-different-hash-value';
+    const payload = { ...mockPayloadBase, vct: vctUrl, 'vct#integrity': wrongHash };
+
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(rawContent),
+    });
+    (mockHasher as jest.Mock).mockClear();
+
+    await expect(fetchTypeMetadataFromUrl(payload, { hasher: mockHasher })).rejects.toThrow(SDJWTVCError);
+    expect(mockHasher).toHaveBeenCalledWith(rawContent);
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should throw SDJWTVCError if integrity check fails with prefixed hash', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const rawContent = JSON.stringify(mockTypeMetadata);
+    const calculatedCorrectHash = mockHasher(rawContent);
+    const wrongHashClaim = 'sha256-totally-different-hash-value'; // Claim in JWT
+    const payload = { ...mockPayloadBase, vct: vctUrl, 'vct#integrity': wrongHashClaim };
+
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(rawContent),
+    });
+    (mockHasher as jest.Mock).mockClear();
+
+    await expect(fetchTypeMetadataFromUrl(payload, { hasher: mockHasher })).rejects.toThrow(
+      `Type Metadata integrity check failed for ${vctUrl}. Expected hash totally-different-hash-value (derived from ${wrongHashClaim}), got ${calculatedCorrectHash}.`,
+    );
+    expect(mockHasher).toHaveBeenCalledWith(rawContent);
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should not perform integrity check if hasher is not provided, even if vct#integrity is present', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const rawContent = JSON.stringify(mockTypeMetadata);
+    const contentHash = mockHasher(rawContent); // Generate hash for payload
+    const payload = { ...mockPayloadBase, vct: vctUrl, 'vct#integrity': contentHash };
+
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(rawContent),
+    });
+    (mockHasher as jest.Mock).mockClear(); // Clear calls from contentHash generation
+
+    const result = await fetchTypeMetadataFromUrl(payload); // No hasher in options
+    expect(result).toEqual(mockTypeMetadata);
+    expect(mockHasher).not.toHaveBeenCalled(); // fetchTypeMetadataFromUrl should not call it
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should not perform integrity check if vct#integrity is not present, even if hasher is provided', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const rawContent = JSON.stringify(mockTypeMetadata);
+    const payload = { ...mockPayloadBase, vct: vctUrl }; // No vct#integrity
+
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(rawContent),
+    });
+    (mockHasher as jest.Mock).mockClear();
+
+    const result = await fetchTypeMetadataFromUrl(payload, { hasher: mockHasher });
+    expect(result).toEqual(mockTypeMetadata);
+    expect(mockHasher).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+  });
+
+  it('should re-throw SDJWTVCError if integrity check itself throws it (e.g. hasher misbehaves)', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const rawContent = JSON.stringify(mockTypeMetadata);
+    const integrityClaim = 'sha256-somehash';
+    const payload = { ...mockPayloadBase, vct: vctUrl, 'vct#integrity': integrityClaim };
+
+    (global as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(rawContent),
+    });
+
+    (mockHasher as jest.Mock).mockImplementationOnce(() => {
+      throw new SDJWTVCError('Deliberate SDJWTVCError from hasher');
+    });
+
+    await expect(fetchTypeMetadataFromUrl(payload, { hasher: mockHasher })).rejects.toThrow(
+      new SDJWTVCError('Deliberate SDJWTVCError from hasher'),
+    );
+  });
+
+  it('should return null and warn for general errors during fetch operation', async () => {
+    const vctUrl = 'https://example.com/metadata.json';
+    const payload = { ...mockPayloadBase, vct: vctUrl };
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (global as any).fetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await fetchTypeMetadataFromUrl(payload);
+    expect(result).toBeNull();
+    expect(fetch).toHaveBeenCalledWith(vctUrl);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Error fetching Type Metadata from ${vctUrl}: Network failure`),
+    );
+    consoleWarnSpy.mockRestore();
+  });
+});
+
+// Ensure existing isValidUrl tests are present and correct
+describe('isValidUrl', () => {
+  it('should return true for valid URLs', () => {
+    expect(isValidUrl('https://example.com')).toBe(true);
+    expect(isValidUrl('http://localhost:3000/path?query=value#hash')).toBe(true);
+    expect(isValidUrl('https://sub.domain.example.co.uk/path.html')).toBe(true);
+  });
+
+  it('should return false for invalid URLs', () => {
+    expect(isValidUrl('not a url')).toBe(false);
+    expect(isValidUrl('example.com')).toBe(false); // Missing scheme
+    expect(isValidUrl('htp://example.com')).toBe(false); // Typo in scheme
+    expect(isValidUrl('https//example.com')).toBe(false); // Missing colon
+    expect(isValidUrl('')).toBe(false);
+    expect(isValidUrl(' https://example.com')).toBe(false); // Leading space
+    expect(isValidUrl('https://example.com/ path')).toBe(false); // Space in path
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -195,7 +195,7 @@ export async function fetchTypeMetadataFromUrl(
   sdJwtPayload: SDJWTPayload,
   options?: { hasher?: SDJWTHasher; algorithmPrefixes?: string[] },
 ): Promise<TypeMetadata | null> {
-  const DEFAULT_ALGORITHM_PREFIXES = ['sha256-', 'sha512-'];
+  const DEFAULT_ALGORITHM_PREFIXES = ['sha256-', 'sha384-', 'sha512-']; // as per https://www.w3.org/TR/sri-2/#integrity-metadata-description
 
   const vct = sdJwtPayload.vct;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -218,24 +218,15 @@ export async function fetchTypeMetadataFromUrl(
       const calculatedHash = await Promise.resolve(options.hasher(rawContent));
 
       // Extract hash from integrity claim, handling algorithm prefixes properly
-      let expectedHash = integrityClaimValue;
+      const matchingPrefix = DEFAULT_ALGORITHM_PREFIXES.find((prefix) => integrityClaimValue.startsWith(prefix));
 
-      // Check for known algorithm prefixes
-      const algorithmPrefixes = DEFAULT_ALGORITHM_PREFIXES;
-      let foundPrefix = false;
-      for (const prefix of algorithmPrefixes) {
-        if (integrityClaimValue.startsWith(prefix)) {
-          expectedHash = integrityClaimValue.substring(prefix.length);
-          foundPrefix = true;
-          break;
-        }
-      }
-
-      if (!foundPrefix) {
+      if (!matchingPrefix) {
         throw new SDJWTVCError(
-          `Invalid algorithm prefix in vct#integrity claim: ${integrityClaimValue}. Expected one of: ${algorithmPrefixes.join(', ')}`,
+          `Invalid algorithm prefix in vct#integrity claim: ${integrityClaimValue}. Expected one of: ${DEFAULT_ALGORITHM_PREFIXES.join(', ')}`,
         );
       }
+
+      const expectedHash = integrityClaimValue.substring(matchingPrefix.length);
 
       if (calculatedHash !== expectedHash) {
         throw new SDJWTVCError(


### PR DESCRIPTION
- `extractEmbeddedTypeMetadata()` utility function to extract and decode Type Metadata documents embedded in the `vctm` unprotected header of SD-JWT VCs
- `fetchTypeMetadataFromUrl()` utility function to fetch and optionally verify Type Metadata from URLs specified in the `vct` claim, with integrity validation support