### PR TITLE
fix: remove jose dependency, use @meeco/sd-jwt for header decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 - 2025-09-30
+
+### Fixed
+
+- Removed broken `jose` dependency from runtime dependencies by replacing `decodeProtectedHeader` with existing `@meeco/sd-jwt` library's `decodeJWT().header` functionality
+
 ## 2.0.0 - 2025-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt-vc",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@meeco/sd-jwt": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "SD-JWT VC implementation in typescript",
   "scripts": {
     "build": "tsc",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
 import { base64decode, decodeJWT, JWK, Hasher as SDJWTHasher, SDJWTPayload } from '@meeco/sd-jwt';
-import { decodeProtectedHeader } from 'jose';
 import { SDJWTVCError } from './errors.js';
 import { JWT, SD_JWT_FORMAT_SEPARATOR, TypeMetadata } from './types.js';
 
@@ -152,7 +151,8 @@ export function extractEmbeddedTypeMetadata(sdJwtVC: JWT): TypeMetadata[] | null
   const jws = parts[0];
 
   try {
-    const protectedHeader = decodeProtectedHeader(jws);
+    const decodedJWT = decodeJWT(jws);
+    const protectedHeader = decodedJWT.header;
 
     // Check if header is valid and has vctm
     if (!protectedHeader || typeof protectedHeader !== 'object') {


### PR DESCRIPTION
Remove `jose` dependency, use `@meeco/sd-jwt` for header decoding