### PR TITLE
allow dc+sd-jwt without cnf claim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 # OS
 .DS_Store
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "snyk.advanced.autoSelectOrganization": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "snyk.advanced.autoSelectOrganization": true
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project (loosely) adheres to [Semantic Versioning](https://semver.org/s
 
 ### Added
 
-- Added support to create SD-JWT VCs with other types of `cnf` type claim and also without `cnf` claim.
+- Added support to create SD-JWT VC without `cnf` claim.
+- Added support to create SD-JWT VC with other types of `cnf` type claim
 
 ## 2.1.0 - 2025-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.0 - 2026-02-04
+
+### Added
+
+- Added support to create SD-JWT VCs with other types of `cnf` type claim and also without `cnf` claim.
+
 ## 2.1.0 - 2025-09-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt-vc",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@meeco/sd-jwt": "^1.2.1"
       },
@@ -74,6 +74,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1796,6 +1797,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
       "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1859,6 +1861,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.8.0.tgz",
       "integrity": "sha512-uEFUsgR+tl8GmzmLjRqz+VrDv4eoaMqMXW7ruXfgThaAShO9JTciKpEsB+TvnfFfbg5IpujgMXVV36gOJRLtZg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.8.0",
         "@typescript-eslint/types": "8.8.0",
@@ -2032,6 +2035,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2365,6 +2369,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -3004,6 +3009,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
       "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
@@ -3066,6 +3072,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4237,6 +4244,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5648,6 +5656,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6404,6 +6413,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6582,6 +6592,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "SD-JWT VC implementation in typescript",
   "scripts": {
     "build": "tsc",

--- a/src/issuer.ts
+++ b/src/issuer.ts
@@ -91,14 +91,15 @@ export class Issuer {
     if (!sdJWTPayload.iss || !isValidUrl(sdJWTPayload.iss)) {
       throw new SDJWTVCError('Issuer iss (issuer) is required and must be a valid URL');
     }
+
     if (!sdJWTPayload.iat || typeof sdJWTPayload.iat !== 'number') {
       throw new SDJWTVCError('Payload iat (Issued at - seconds since Unix epoch) is required and must be a number');
     }
-    if (!sdJWTPayload.cnf || typeof sdJWTPayload.cnf !== 'object' || !sdJWTPayload.cnf.jwk) {
-      throw new SDJWTVCError('Payload cnf is required and must be a JWK format');
-    }
-    if (typeof sdJWTPayload.cnf.jwk !== 'object' || typeof sdJWTPayload.cnf.jwk.kty !== 'string') {
-      throw new SDJWTVCError('Payload cnf.jwk must be valid JWK format');
+
+    if (sdJWTPayload.cnf && sdJWTPayload.cnf.jwk) {
+      if (typeof sdJWTPayload.cnf.jwk !== 'object' || typeof sdJWTPayload.cnf.jwk.kty !== 'string') {
+        throw new SDJWTVCError('Payload cnf.jwk must be valid JWK format');
+      }
     }
 
     if (!sdJWTPayload.vct || typeof sdJWTPayload.vct !== 'string') {
@@ -106,6 +107,7 @@ export class Issuer {
     }
 
     const prefixes = ['http', 'https', 'https://', 'http://'];
+
     if (
       prefixes.some((prefix) => (sdJWTPayload.vct as string).startsWith(prefix)) &&
       !isValidUrl(sdJWTPayload.vct as any)

--- a/src/issuer.ts
+++ b/src/issuer.ts
@@ -96,10 +96,11 @@ export class Issuer {
       throw new SDJWTVCError('Payload iat (Issued at - seconds since Unix epoch) is required and must be a number');
     }
 
-    if (sdJWTPayload.cnf && sdJWTPayload.cnf.jwk) {
-      if (typeof sdJWTPayload.cnf.jwk !== 'object' || typeof sdJWTPayload.cnf.jwk.kty !== 'string') {
-        throw new SDJWTVCError('Payload cnf.jwk must be valid JWK format');
-      }
+    if (
+      sdJWTPayload.cnf?.jwk &&
+      (typeof sdJWTPayload.cnf.jwk !== 'object' || typeof sdJWTPayload.cnf.jwk.kty !== 'string')
+    ) {
+      throw new SDJWTVCError('Payload cnf.jwk must be valid JWK format');
     }
 
     if (!sdJWTPayload.vct || typeof sdJWTPayload.vct !== 'string') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface JWTHeader {
 export interface CreateSDJWTPayload extends JWTPayload {
   iss: string;
   iat: number;
-  cnf: Cnf;
+  cnf?: Cnf;
   vct: string;
   status?: Record<string, any>;
 }


### PR DESCRIPTION
Minor update to remove the `cnf` claim requirement when creating an SD JWT VC