### PR TITLE
fix: reserve integrity metadata claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.2 - 2026-06-22
+
+### Fixed
+
+- Added integrity metadata keys (`vct#integrity`, `extends#integrity`, `schema_uri#integrity`) to reserved JWT claim keys.
+- Updated `@meeco/sd-jwt` dependency to `1.2.3`.
+
 ## 2.2.0 - 2026-02-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt-vc",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
-        "@meeco/sd-jwt": "^1.2.1"
+        "@meeco/sd-jwt": "^1.2.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
@@ -1593,9 +1593,9 @@
       }
     },
     "node_modules/@meeco/sd-jwt": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@meeco/sd-jwt/-/sd-jwt-1.2.1.tgz",
-      "integrity": "sha512-I2PdEvOzvlwhisjU/Ta28JDLvs+04qP6d0k6/3VJAlDjbygobme6TeHsgvAuToetjuXCCqAhaVZlwZ628prT8Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@meeco/sd-jwt/-/sd-jwt-1.2.3.tgz",
+      "integrity": "sha512-S9hmXM0dshLECunIxZqpdpWTlOHQxpe7sNl9FUr7s+onNaOEl+S7ErmvBYLWkoMfYcNGugYlE32u1KbqJv+McA==",
       "engines": {
         "node": ">=18",
         "npm": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt-vc",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "SD-JWT VC implementation in typescript",
   "scripts": {
     "build": "tsc",
@@ -66,6 +66,6 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "@meeco/sd-jwt": "^1.2.1"
+    "@meeco/sd-jwt": "^1.2.3"
   }
 }

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -435,6 +435,12 @@ describe('Issuer', () => {
       );
     });
 
+    it('should reserve integrity metadata keys', () => {
+      expect(ReservedJWTClaimKeys).toEqual(
+        expect.arrayContaining(['vct#integrity', 'extends#integrity', 'schema_uri#integrity']),
+      );
+    });
+
     it('should not throw an error if all properties are valid', () => {
       const claims = {
         person: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,11 +67,19 @@ export interface JSONWebKeySet {
 export type NonceGenerator = (length?: number) => string;
 
 export type CreateSDJWTPayloadKeys = keyof CreateSDJWTPayload;
-export const ReservedJWTClaimKeys: CreateSDJWTPayloadKeys[] = [
+export type ReservedJWTClaimKey =
+  | CreateSDJWTPayloadKeys
+  | 'vct#integrity'
+  | 'extends#integrity'
+  | 'schema_uri#integrity';
+export const ReservedJWTClaimKeys: ReservedJWTClaimKey[] = [
   'iss',
   'iat',
   'cnf',
   'vct',
+  'vct#integrity',
+  'extends#integrity',
+  'schema_uri#integrity',
   'status',
   'jti',
   'sub',


### PR DESCRIPTION
Reserve SD-JWT VC integrity metadata claim keys so they cannot be supplied as regular VC claims or selectively disclosed claims.